### PR TITLE
Add Russian (ru) README and translations

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <sub><a href="README.md">English</a> · <b>Español</b> · <a href="README.zh-CN.md">中文</a></sub>
+  <sub><a href="README.md">English</a> · <b>Español</b> · <a href="README.zh-CN.md">中文</a> · <a href="README.ru.md">Русский</a></sub>
 </div>
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <sub><b>English</b> · <a href="README.es.md">Español</a> · <a href="README.zh-CN.md">中文</a></sub>
+  <sub><b>English</b> · <a href="README.es.md">Español</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ru.md">Русский</a></sub>
 </div>
 
 <br/>

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,281 @@
+<div align="right">
+  <sub><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.zh-CN.md">中文</a> · <b>Русский</b></sub>
+</div>
+
+<br/>
+
+<div align="center">
+
+<img src="assets/icon.svg" width="120" alt="Логотип Streak" />
+
+# Streak
+
+### Минималистичный, приватный трекер привычек без рекламы
+
+Отмечайте привычку одним касанием, сохраняйте темп и наблюдайте, как растут ваши серии.
+
+<br/>
+
+<p>
+  <img alt="Flutter" src="https://img.shields.io/badge/Flutter-02569B?style=flat&logo=flutter&logoColor=white" />
+  <img alt="Dart" src="https://img.shields.io/badge/Dart-0175C2?style=flat&logo=dart&logoColor=white" />
+  <img alt="Android" src="https://img.shields.io/badge/Android-3DDC84?style=flat&logo=android&logoColor=white" />
+  <img alt="Лицензия GPLv3" src="https://img.shields.io/badge/License-GPLv3-7C3AED?style=flat&logo=gnu&logoColor=white" />
+  <img alt="Без рекламы, без слежки" src="https://img.shields.io/badge/No%20ads%20%C2%B7%20No%20tracking-22C55E?style=flat&logo=shield&logoColor=white" />
+</p>
+<a href="https://trendshift.io/repositories/79460?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-79460" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/79460/daily?language=Dart" alt="InlitX%2Fstreak | Trendshift" width="250" height="55"/></a>
+
+<br/>
+
+<a href="https://f-droid.org/packages/com.streak.app/"><img alt="Доступно в F-Droid" src="assets/badges/get-it-on-fdroid.png" height="60" /></a>
+&nbsp;
+<a href="https://apt.izzysoft.de/fdroid/index/apk/com.streak.app?repo=main"><img alt="Доступно в IzzyOnDroid" src="assets/badges/get-it-on-izzyondroid.png" height="60" /></a>
+&nbsp;
+<a href="https://www.openapk.net/streak/com.streak.app/"><img alt="Доступно на OpenAPK" src="assets/badges/get-it-on-openapk.png" height="60" /></a>
+&nbsp;
+<a href="https://github.com/InlitX/streak/releases"><img alt="Доступно на GitHub" src="assets/badges/get-it-on-github.png" height="60" /></a>
+
+<br/>
+
+<sub>
+  <a href="#-возможности">Возможности</a> ·
+  <a href="#переходите-с-другого-приложения">Импорт</a> ·
+  <a href="#скачать">Скачать</a> ·
+  <a href="#конфиденциальность">Конфиденциальность</a> ·
+  <a href="#переводы">Переводы</a>
+</sub>
+
+</div>
+
+---
+
+<div align="center">
+
+<img src="screenshots/01-today.png" alt="Сегодня" width="150" />
+<img src="screenshots/02-stats.png" alt="Статистика" width="150" />
+<img src="screenshots/03-insights.png" alt="Аналитика" width="150" />
+<img src="screenshots/04-customize.png" alt="Персонализация" width="150" />
+<img src="screenshots/05-free.png" alt="Бесплатно и приватно" width="150" />
+
+<sub><b>Сегодня</b> · <b>Статистика</b> · <b>Аналитика</b> · <b>Персонализация</b> · <b>Бесплатно и приватно</b></sub>
+
+</div>
+
+---
+
+## Обзор
+
+Streak — трекер привычек с открытым исходным кодом для Android, который уважает
+вас. Создавайте сколько угодно привычек, отмечайте их одним касанием и наблюдайте,
+как растёт прогресс в сетке активности в стиле GitHub, счётчиках серий и на панели
+статистики.
+
+Приложение быстрое, работает офлайн и создано для спокойствия, а не давления.
+
+> [!TIP]
+> **Полностью ваше.** Никаких аккаунтов, подписок, рекламы и слежки. Каждая
+> привычка и настройка остаются на вашем устройстве — а весь код открыт.
+
+---
+
+## ✨ Возможности
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### ✅ Отслеживание
+
+- Отметка одним касанием с главного экрана или виджета
+- Три типа привычек — **обычная**, **избегать** (с учётом срывов) и
+  **количество** (вода, чтение или своя единица измерения и дневная цель)
+- **Чек-листы** разбивают привычку на шаги, она засчитывается только когда
+  отмечены все шаги
+- **Гибкое расписание** — ежедневно, X раз в неделю или месяц, выбранные дни
+  недели или каждые N дней
+- **Заполнение прошлого** — нажмите на любой день, чтобы добавить или убрать
+  отметку, серии пересчитаются
+- **Заметки к дню** — долгое нажатие на день, чтобы записать, что произошло,
+  запланировать что-то заранее или прикрепить фото
+- Счётчики текущей и лучшей серии
+- **Режим отпуска** ставит привычку на паузу, ничего не ломая
+- Завершённые привычки опускаются вниз списка, чтобы было видно, что осталось
+
+</td>
+<td width="50%" valign="top">
+
+### 📊 Просмотр прогресса
+
+- **Сетка активности** в стиле GitHub — неделя, месяц или год
+- **Календарь месяца** с началом недели в понедельник, субботу или воскресенье
+- **Выполнения по месяцам**, чтобы увидеть форму целого года
+- **Динамика серии** на графике — наблюдайте, как растёт линия
+- **«Когда вы наиболее последовательны?»** находит часы, в которые вы
+  действительно справляетесь
+- Итоги, лучшая серия, текущая серия и процент выполнения в одной строке
+- Показатель **силы** для каждой привычки с упором на недавние дни
+- **Карточка прогресса** для публикации в нескольких размерах, экспортируется
+  как готовое изображение
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+### 🧘 Сессии фокусировки
+
+- Таймер для привычек, которым он нужен — свободный или привязанный к привычке
+  и её цели
+- **Раунды помодоро** с короткими перерывами или один длинный отрезок
+- Три стиля циферблата — **Круг**, **Флип** и **Точки**
+- Встроенные звуки — дождь, коричневый шум, тёплый пэд — или свои треки,
+  по порядку или вперемешку
+- Спокойные сцены на фоне или собственное фото
+- Отмечайте подзадачи, не выходя из таймера, и держите экран включённым
+- **Дневная цель фокусировки**, а также история всех завершённых сессий
+- Минуты засчитываются самой привычке при достижении цели
+
+</td>
+<td width="50%" valign="top">
+
+### 🎨 Настройка под себя
+
+- **Классический или Минимальный** стиль — список привычек с нижней панелью
+  или сетка со всем, сгруппированным в четыре раздела
+- Минималистичный набор значков или любой эмодзи
+- Свой акцентный цвет с полным выбором палитры
+- Светлая и тёмная темы, а также пять фонов — сплошной, градиент, точки,
+  истинно чёрный OLED или собственное фото
+- Обложки, категории, изменение порядка перетаскиванием, имя и фото профиля
+- Три значка приложения, чтобы Streak сочетался с остальным главным экраном
+- Взрыв конфетти в день, когда выполнено всё
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+### 🔔 Напоминания и виджеты
+
+- Напоминания для каждой привычки в выбранные дни или каждые N дней, каждое
+  с короткой ободряющей фразой вместо пустого уведомления
+- **Четыре виджета на главном экране** — привычка, сегодня, статистика и сетка
+  активности — у каждого свой стиль: цвет или фото, прозрачность и рамка
+- Выберите, какие показатели отображает **виджет статистики** и как они
+  расположены
+- Отмечайте день прямо с виджета — сохраняется без открытия приложения
+- Нажмите на сетку активности, чтобы перейти к этой привычке
+
+</td>
+<td width="50%" valign="top">
+
+### 💾 Ваши данные
+
+- **Импорт** из Loop Habit Tracker и HabitKit вместе с историей и сериями
+- Резервное копирование и восстановление одним файлом, который храните вы сами
+- Всё работает офлайн — без аккаунта, без сервера, нечего синхронизировать
+- Английский, испанский и китайский языки, ещё больше языков открыто на Weblate
+
+</td>
+</tr>
+</table>
+
+---
+
+## Переходите с другого приложения?
+
+Перенесите свою историю с собой. Streak читает экспорт из **Loop Habit Tracker**
+и **HabitKit**, поэтому прошедшие дни и серии переживают переезд. Поддержка
+других приложений уже готовится.
+
+<div align="center"><sub><b>Настройки → Данные → Импорт из другого приложения</b></sub></div>
+
+---
+
+## Скачать
+
+[**F-Droid**](https://f-droid.org/packages/com.streak.app/) — самый простой
+способ: устанавливает Streak и поддерживает его в актуальном состоянии.
+Также доступно на
+[**IzzyOnDroid**](https://apt.izzysoft.de/fdroid/index/apk/com.streak.app?repo=main)
+и [**OpenAPK**](https://www.openapk.net/streak/com.streak.app/).
+
+Предпочитаете обычный APK? Он на странице
+[**Releases**](https://github.com/InlitX/streak/releases), по одному файлу на
+тип телефона, чтобы каждая загрузка была небольшой:
+
+| APK | Для |
+|-----|-----|
+| `Streak-arm64-v8a.apk` | Современные 64-битные телефоны — **выберите этот** |
+| `Streak-armeabi-v7a.apk` | Старые 32-битные устройства |
+| `Streak-x86_64.apk` | Эмуляторы и планшеты x86 |
+
+Работает на **Android 9 (Pie) и новее**.
+
+> [!NOTE]
+> Streak отсутствует в Play Store. Поскольку APK не из магазина, при первой
+> установке Android может попросить разрешить установку из вашего браузера
+> или файлового менеджера.
+
+---
+
+## Конфиденциальность
+
+> [!IMPORTANT]
+> В Streak **нет аналитики, рекламных SDK и серверного бэкенда**. Приложение
+> никогда никуда не отправляет ваши данные — они остаются на вашем устройстве.
+> Единственные исходящие действия — это ссылки, которые вы сами решаете открыть.
+
+---
+
+## Переводы
+
+Сегодня Streak говорит на английском, испанском и китайском, и новые языки
+очень приветствуются.
+Переводы ведутся на [**Weblate**](https://hosted.weblate.org/engage/streak/):
+программирование не нужно, только короткие фразы, которые вы переводите
+в браузере.
+
+[![Статус перевода по языкам](https://hosted.weblate.org/widget/streak/app-strings/multi-auto.svg)](https://hosted.weblate.org/engage/streak/)
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[![Статус перевода](https://hosted.weblate.org/widget/streak/287x66-grey.png)](https://hosted.weblate.org/engage/streak/)
+
+Как это работает → [**TRANSLATING.md**](TRANSLATING.md)
+
+---
+
+## Вклад в проект
+
+Сообщения об ошибках, идеи и pull request'ы приветствуются — см.
+[**CONTRIBUTING.md**](CONTRIBUTING.md). Для чего-то большего, чем небольшое
+исправление, сначала откройте issue, чтобы согласовать направление.
+
+---
+
+## Поддержка
+
+<div align="center">
+
+Если Streak помогает вам действовать чаще, звезда или чашка кофе значат многое.
+
+<a href="https://github.com/InlitX/streak"><img src="https://img.shields.io/badge/Star%20on%20GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="Звезда на GitHub" height="38" /></a>
+&nbsp;&nbsp;
+<a href="https://ko-fi.com/inlitx"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Поддержать на Ko-fi" height="38" /></a>
+
+<br/>
+<br/>
+
+<a href="https://www.star-history.com/?repos=InlitX%2Fstreak&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=InlitX/streak&type=date&theme=dark&legend=top-left&sealed_token=aNqDTOocHK1NkSrMsZrD1iFDpo1AtZvvUo3ZqETCzSujh-eSh0ekwpay4FpVGocizt1wmR5QWrkuMUAl2r9yllwF4v9e3tnsI6c1lv0upumuFVgsXGvAwA" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=InlitX/streak&type=date&legend=top-left&sealed_token=aNqDTOocHK1NkSrMsZrD1iFDpo1AtZvvUo3ZqETCzSujh-eSh0ekwpay4FpVGocizt1wmR5QWrkuMUAl2r9yllwF4v9e3tnsI6c1lv0upumuFVgsXGvAwA" />
+   <img alt="История звёзд" src="https://api.star-history.com/chart?repos=InlitX/streak&type=date&legend=top-left&sealed_token=aNqDTOocHK1NkSrMsZrD1iFDpo1AtZvvUo3ZqETCzSujh-eSh0ekwpay4FpVGocizt1wmR5QWrkuMUAl2r9yllwF4v9e3tnsI6c1lv0upumuFVgsXGvAwA" />
+ </picture>
+</a>
+
+<br/>
+<br/>
+
+Распространяется по лицензии <a href="LICENSE"><b>GNU GPLv3</b></a>.
+
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <div align="right">
-  <sub><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <b>中文</b></sub>
+  <sub><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <b>中文</b> · <a href="README.ru.md">Русский</a></sub>
 </div>
 
 <br/>


### PR DESCRIPTION
## Summary
- Add README.ru.md — full Russian translation of the README
- Update language switcher in README.md, README.es.md and README.zh-CN.md to link to the Russian version